### PR TITLE
Use the Sery version from my namespace

### DIFF
--- a/tests/ok/sery.cpp
+++ b/tests/ok/sery.cpp
@@ -3,7 +3,7 @@ local_settings:
     build:
         cxx_flags: -std=c++11
 dependencies:
-    pvt.cppan.demo.ninetainedo.sery
+    pvt.ninetainedo.sery
 */
 
 #include <Sery/Buffer.hh>


### PR DESCRIPTION
Just so that it references the proper one.